### PR TITLE
hotfix: 連撃系の火力指数が狂っているのを修正 + local debug用コミット

### DIFF
--- a/lib/koto-display.php
+++ b/lib/koto-display.php
@@ -1102,7 +1102,8 @@ function get_koto_sugowaza_html($condition_data = null, $group_data, $skill_type
                             $at_rate_array[] = ['rate' => (float)$eff_val, 'hit_count' => 3];
                             break;
                         case 'command':
-                            $effect_text = "わざ・すごわざを発動した味方が{$target_name}に{$eff_val}倍の{$attack_attr}属性攻撃";
+                            $target_phrase = $target_name ? "{$target_name}に" : '';
+                            $effect_text = "わざ・すごわざを発動した味方が{$target_phrase}{$eff_val}倍の{$attack_attr}属性攻撃";
                             $at_rate_array[] = ['rate' => (float)$eff_val, 'hit_count' => 3];
                             break;
                         case 'waza_command':

--- a/lib/koto-display.php
+++ b/lib/koto-display.php
@@ -1054,7 +1054,9 @@ function get_koto_sugowaza_html($condition_data = null, $group_data, $skill_type
                             } else {
                                 $base_phrase = "{$saidai_text}{$eff_val}倍の{$omni_text}{$mod_text}{$attr_text}{$atk_noun}";
                             }
-                            $at_rate_array[] = ['rate' => $raw_eff_val, 'hit_count' => 1];
+                            if ($hit_count <= 1) {
+                                $at_rate_array[] = ['rate' => $raw_eff_val, 'hit_count' => 1];
+                            }
 
                             $effect_text = "{$target_name}に{$base_phrase}";
 

--- a/local-dev/plugin/kotodaman-local-runtime.php
+++ b/local-dev/plugin/kotodaman-local-runtime.php
@@ -53,3 +53,205 @@ add_filter('option_blogdescription', function ($description) {
 
     return 'Local WordPress environment for the Kotodaman database theme.';
 });
+
+if (!function_exists('kotodaman_local_get_term_stub')) {
+    function kotodaman_local_get_term_stub($taxonomy, $slug, $fallback_name = '')
+    {
+        $slug = trim((string) $slug);
+        if ($slug === '') {
+            return null;
+        }
+
+        $term = get_term_by('slug', $slug, $taxonomy);
+        if ($term && !is_wp_error($term)) {
+            return $term;
+        }
+
+        return (object) [
+            'slug' => $slug,
+            'name' => $fallback_name !== '' ? $fallback_name : $slug,
+        ];
+    }
+}
+
+if (!function_exists('kotodaman_local_build_target_terms')) {
+    function kotodaman_local_build_target_terms($type, $objects)
+    {
+        $objects = is_array($objects) ? $objects : [];
+        $terms = [];
+
+        foreach ($objects as $object) {
+            $slug = trim((string) ($object['slug'] ?? ''));
+            $name = trim((string) ($object['name'] ?? $slug));
+
+            if ($type === 'attr') {
+                $terms[] = kotodaman_local_get_term_stub('attribute', $slug, $name);
+            } elseif ($type === 'species') {
+                $terms[] = kotodaman_local_get_term_stub('species', $slug, $name);
+            } elseif ($type === 'group') {
+                $terms[] = kotodaman_local_get_term_stub('affiliation', $slug, $name);
+            }
+        }
+
+        return array_values(array_filter($terms));
+    }
+}
+
+if (!function_exists('kotodaman_local_build_advantage_target')) {
+    function kotodaman_local_build_advantage_target($target)
+    {
+        $type = $target['type'] ?? '';
+        if ($type === '') {
+            return null;
+        }
+
+        return [
+            'target_type' => $type,
+            'target_attr' => $type === 'attr' ? kotodaman_local_build_target_terms('attr', $target['obj'] ?? []) : [],
+            'target_species' => $type === 'species' ? kotodaman_local_build_target_terms('species', $target['obj'] ?? []) : [],
+            'target_group' => $type === 'group' ? kotodaman_local_build_target_terms('group', $target['obj'] ?? []) : [],
+            'target_other' => $type === 'other' ? trim((string) (($target['obj'][0]['name'] ?? ''))) : '',
+        ];
+    }
+}
+
+if (!function_exists('kotodaman_local_build_skill_detail_from_timeline')) {
+    function kotodaman_local_build_skill_detail_from_timeline($timeline)
+    {
+        $target = $timeline['target'] ?? [];
+        $target_type = $target['type'] ?? '';
+        $target_objects = $target['obj'] ?? [];
+        $element_slug = trim((string) ($timeline['element'] ?? ''));
+        $attack_attr = $element_slug !== '' ? kotodaman_local_get_term_stub('attribute', $element_slug) : null;
+
+        $detail = [
+            'waza_type' => $timeline['type'] ?? '',
+            'waza_target' => $target['main'] ?? '',
+            'waza_target_detail' => $target_type !== '' ? $target_type : 'none',
+            'target_detail_attr' => $target_type === 'attr' ? kotodaman_local_build_target_terms('attr', $target_objects) : [],
+            'target_detail_species' => $target_type === 'species' ? kotodaman_local_build_target_terms('species', $target_objects) : [],
+            'target_detail_group' => $target_type === 'group' ? kotodaman_local_build_target_terms('group', $target_objects) : [],
+            'target_detail_other' => $target_type === 'other' ? trim((string) (($target_objects[0]['name'] ?? ''))) : '',
+            'waza_value' => (float) ($timeline['value'] ?? 0),
+            'waza_value_last' => (float) ($timeline['value_last'] ?? 0),
+            'hit_count' => (int) ($timeline['hit_count'] ?? 1),
+            'turn_count' => (int) ($timeline['turn_count'] ?? 1),
+            'attack_attr' => $attack_attr,
+            'attack_type' => is_array($timeline['attack_type'] ?? null) ? $timeline['attack_type'] : [],
+            'target_status' => $timeline['resist_status'] ?? '',
+            'pressure_debuff_count' => !empty($timeline['pressure_debuff']) ? implode(',', (array) $timeline['pressure_debuff']) : '',
+            'omni_advantage' => !empty($timeline['omni_advantage']),
+            'is_moji_healing' => !empty($timeline['is_moji_healing']),
+            'moji_exhaust' => !empty($timeline['moji_exhaust']),
+            'battle_field_loop' => [],
+        ];
+
+        if (!empty($timeline['color_order']) && is_array($timeline['color_order'])) {
+            $detail['colorfull_attack_attr'] = array_values(array_filter(array_map(function ($slug) {
+                return kotodaman_local_get_term_stub('attribute', $slug);
+            }, $timeline['color_order'])));
+        }
+
+        if (!empty($timeline['at_type_target']) && is_array($timeline['at_type_target'])) {
+            $detail['advantage_target'] = kotodaman_local_build_advantage_target($timeline['at_type_target']);
+        }
+
+        if (!empty($timeline['killer_rate'])) {
+            $detail['advantage_rate'] = (float) $timeline['killer_rate'];
+        }
+
+        return $detail;
+    }
+}
+
+if (!function_exists('kotodaman_local_build_skill_groups_from_spec')) {
+    function kotodaman_local_build_skill_groups_from_spec($variations, $skill_type = 'sugo', $shift_type = 'none')
+    {
+        if (empty($variations) || !is_array($variations)) {
+            return null;
+        }
+
+        $groups = [];
+        foreach ($variations as $variation) {
+            $group = [
+                'waza_add_cond_loop' => [],
+            ];
+
+            if ($skill_type === 'waza') {
+                $group['waza_detail_loop'] = [];
+            } elseif ($skill_type === 'kotowaza') {
+                $group['kotowaza_detail_loop'] = [];
+            } else {
+                $group['sugo_detail_loop'] = [];
+            }
+
+            if ($shift_type === 'attr' && !empty($variation['shift_value'])) {
+                $group_key = $skill_type === 'kotowaza' ? 'kotowaza_shift_attr' : 'sugo_shift_attr';
+                $group[$group_key] = array_values(array_filter(array_map(function ($slug) {
+                    return kotodaman_local_get_term_stub('attribute', $slug);
+                }, (array) $variation['shift_value'])));
+            }
+            if ($shift_type === 'moji' && !empty($variation['shift_value'])) {
+                $group_key = $skill_type === 'kotowaza' ? 'kotowaza_shift_moji' : 'sugo_shift_moji';
+                $group[$group_key] = array_map(function ($value) {
+                    return (object) ['name' => $value];
+                }, (array) $variation['shift_value']);
+            }
+            if ($shift_type === 'attacked' && !empty($variation['shift_value'][0])) {
+                $group_key = $skill_type === 'kotowaza' ? 'kotowaza_shift_attacked' : 'sugo_shift_attacked';
+                $group[$group_key] = $variation['shift_value'][0];
+            }
+            if ($shift_type === 'random' && !empty($variation['shift_value'][0])) {
+                $group['random_count'] = $variation['shift_value'][0];
+            }
+
+            foreach (($variation['timelines'] ?? []) as $timeline) {
+                $detail = kotodaman_local_build_skill_detail_from_timeline($timeline);
+                if ($skill_type === 'waza') {
+                    $group['waza_detail_loop'][] = $detail;
+                } elseif ($skill_type === 'kotowaza') {
+                    $group['kotowaza_detail_loop'][] = $detail;
+                } else {
+                    $group['sugo_detail_loop'][] = $detail;
+                }
+            }
+
+            $groups[] = $group;
+        }
+
+        return $groups;
+    }
+}
+
+if (!function_exists('kotodaman_local_build_sugowaza_conditions_from_spec')) {
+    function kotodaman_local_build_sugowaza_conditions_from_spec($condition_patterns)
+    {
+        if (empty($condition_patterns) || !is_array($condition_patterns)) {
+            return null;
+        }
+
+        $patterns = [];
+        foreach ($condition_patterns as $pattern) {
+            $row = [
+                'get_palce' => $pattern['get_place'] ?? 'default',
+                'need_blessing_point' => $pattern['need_point'] ?? '',
+                'sugo_cond_loop' => [],
+            ];
+
+            foreach (($pattern['conditions'] ?? []) as $condition) {
+                $values = isset($condition['values']) && is_array($condition['values'])
+                    ? implode(',', $condition['values'])
+                    : '';
+
+                $row['sugo_cond_loop'][] = [
+                    'sugo_cond_type' => $condition['type'] ?? '',
+                    'sugo_cond_val' => $values,
+                ];
+            }
+
+            $patterns[] = $row;
+        }
+
+        return $patterns;
+    }
+}

--- a/local-dev/seed/import-test-specs.php
+++ b/local-dev/seed/import-test-specs.php
@@ -1,0 +1,292 @@
+<?php
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+global $wpdb;
+
+$theme_dir = get_stylesheet_directory();
+$spec_dir = $theme_dir . '/testdata/spec-json';
+
+if (!is_dir($spec_dir)) {
+    throw new RuntimeException('Spec fixture directory not found: ' . $spec_dir);
+}
+
+$attr_labels = [
+    'fire' => '火',
+    'water' => '水',
+    'wood' => '木',
+    'light' => '光',
+    'dark' => '闇',
+    'void' => '冥',
+    'heaven' => '天',
+    'rainbow' => '虹',
+];
+
+$species_labels = [
+    'god' => '神',
+    'demon' => '魔',
+    'hero' => '英',
+    'dragon' => '龍',
+    'beast' => '獣',
+    'spirit' => '霊',
+    'artifact' => '物',
+    'yokai' => '妖',
+];
+
+$rarity_labels = [
+    '6' => '星6',
+    'legend' => 'レジェンド',
+    'grand' => 'グランド',
+];
+
+$gimmick_labels = [
+    'shield' => 'シールドブレイカー',
+    'needle' => 'トゲガード',
+    'change' => 'チェンジガード',
+    'weakening' => '弱体ガード',
+    'wall' => 'ウォールブレイカー',
+    'shock' => 'ビリビリガード',
+    'healing' => 'ヒールブレイカー',
+    'copy' => 'コピーガード',
+    'freezing' => 'フリーズブレイカー',
+    'landmine' => '地雷ガード',
+    'smash' => 'スマッシュブレイカー',
+    'balloon' => 'バルーンガード',
+    'healing_core' => 'ヒールコア',
+    'attack_core' => 'アタックコア',
+    'attack_buff_core' => 'アタックバフコア',
+    'super_attack_core' => 'スーパーアタックコア',
+];
+
+$ensure_term = static function ($taxonomy, $slug, $name, $parent_slug = null) {
+    $parent = 0;
+    if ($parent_slug) {
+        $parent_term = get_term_by('slug', $parent_slug, $taxonomy);
+        if ($parent_term && !is_wp_error($parent_term)) {
+            $parent = (int) $parent_term->term_id;
+        }
+    }
+
+    $existing = get_term_by('slug', $slug, $taxonomy);
+    if ($existing && !is_wp_error($existing)) {
+        wp_update_term($existing->term_id, $taxonomy, [
+            'name' => $name,
+            'slug' => $slug,
+            'parent' => $parent,
+        ]);
+
+        return (int) $existing->term_id;
+    }
+
+    $created = wp_insert_term($name, $taxonomy, [
+        'slug' => $slug,
+        'parent' => $parent,
+    ]);
+
+    if (is_wp_error($created)) {
+        throw new RuntimeException($created->get_error_message());
+    }
+
+    return (int) $created['term_id'];
+};
+
+$gimmick_label = static function ($slug) use ($gimmick_labels) {
+    if (isset($gimmick_labels[$slug])) {
+        return $gimmick_labels[$slug];
+    }
+
+    if (strpos($slug, 'super_') === 0) {
+        $base_slug = substr($slug, 6);
+        $base_label = $gimmick_labels[$base_slug] ?? $base_slug;
+        return 'スーパー' . $base_label;
+    }
+
+    return $slug;
+};
+
+$find_existing_post_id = static function (array $spec) {
+    $spec_id = (int) ($spec['id'] ?? 0);
+    if ($spec_id <= 0) {
+        return 0;
+    }
+
+    $posts = get_posts([
+        'post_type' => 'character',
+        'post_status' => ['publish', 'draft', 'pending', 'future', 'private'],
+        'posts_per_page' => 1,
+        'fields' => 'ids',
+        'meta_key' => '_local_test_spec_id',
+        'meta_value' => (string) $spec_id,
+    ]);
+    if (!empty($posts)) {
+        return (int) $posts[0];
+    }
+
+    $decoded_name = html_entity_decode((string) ($spec['name'] ?? ''), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+    if ($decoded_name === '') {
+        return 0;
+    }
+
+    $posts = get_posts([
+        'post_type' => 'character',
+        'post_status' => ['publish', 'draft', 'pending', 'future', 'private'],
+        'title' => $decoded_name,
+        'posts_per_page' => 1,
+        'fields' => 'ids',
+    ]);
+
+    return !empty($posts) ? (int) $posts[0] : 0;
+};
+
+foreach ($attr_labels as $slug => $label) {
+    $ensure_term('attribute', $slug, $label);
+}
+
+foreach ($species_labels as $slug => $label) {
+    $ensure_term('species', $slug, $label);
+}
+
+$ensure_term('rarity', '6', $rarity_labels['6']);
+$ensure_term('rarity', 'legend', $rarity_labels['legend'], '6');
+$ensure_term('rarity', 'grand', $rarity_labels['grand'], '6');
+
+$spec_files = glob($spec_dir . '/*.json');
+sort($spec_files);
+
+$imported = [];
+
+foreach ($spec_files as $spec_file) {
+    $raw = file_get_contents($spec_file);
+    $spec = json_decode($raw, true);
+
+    if (!is_array($spec) || empty($spec['id'])) {
+        throw new RuntimeException('Invalid spec fixture: ' . basename($spec_file));
+    }
+
+    $spec_id = (int) $spec['id'];
+    $post_title = html_entity_decode((string) ($spec['name'] ?? ''), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+    $post_name = (string) $spec_id;
+    $existing_post_id = $find_existing_post_id($spec);
+
+    $post_args = [
+        'post_type' => 'character',
+        'post_status' => 'publish',
+        'post_title' => $post_title,
+        'post_name' => $post_name,
+        'post_content' => '',
+    ];
+
+    if ($existing_post_id > 0) {
+        $post_args['ID'] = $existing_post_id;
+        $post_id = wp_update_post($post_args, true);
+    } else {
+        $post_id = wp_insert_post($post_args, true);
+    }
+
+    if (is_wp_error($post_id)) {
+        throw new RuntimeException($post_id->get_error_message());
+    }
+
+    $wpdb->update(
+        $wpdb->posts,
+        ['post_name' => $post_name],
+        ['ID' => $post_id],
+        ['%s'],
+        ['%d']
+    );
+    clean_post_cache($post_id);
+
+    update_post_meta($post_id, '_local_test_spec_id', (string) $spec_id);
+    update_post_meta($post_id, '_spec_json', wp_slash(wp_json_encode($spec, JSON_UNESCAPED_UNICODE)));
+    update_post_meta($post_id, 'name_ruby', $spec['name_ruby'] ?? '');
+    update_post_meta($post_id, 'voice_actor', html_entity_decode((string) ($spec['cv'] ?? ''), ENT_QUOTES | ENT_HTML5, 'UTF-8'));
+    update_post_meta($post_id, 'get_place', $spec['acquisition'] ?? '');
+    update_post_meta($post_id, 'impl_date', $spec['release_date'] ?? '');
+    update_post_meta($post_id, '99_hp', (int) ($spec['_val_99_hp'] ?? 0));
+    update_post_meta($post_id, '99_atk', (int) ($spec['_val_99_atk'] ?? 0));
+    update_post_meta($post_id, '120_hp', (int) ($spec['_val_120_hp'] ?? 0));
+    update_post_meta($post_id, '120_atk', (int) ($spec['_val_120_atk'] ?? 0));
+    update_post_meta($post_id, 'talent_hp', (int) ($spec['talent_hp'] ?? 0));
+    update_post_meta($post_id, 'talent_atk', (int) ($spec['talent_atk'] ?? 0));
+    update_post_meta($post_id, 'firepower_index', (int) ($spec['firepower_index'] ?? 0));
+
+    $attr_terms = [];
+    if (!empty($spec['attribute'])) {
+        $attr_terms[] = (string) $spec['attribute'];
+    }
+    if (!empty($spec['sub_attributes']) && is_array($spec['sub_attributes'])) {
+        foreach ($spec['sub_attributes'] as $sub_attr_slug) {
+            $attr_terms[] = (string) $sub_attr_slug;
+        }
+    }
+    $attr_terms = array_values(array_unique(array_filter($attr_terms)));
+
+    $species_terms = !empty($spec['species']) ? [(string) $spec['species']] : [];
+
+    $affiliation_terms = [];
+    foreach (($spec['groups'] ?? []) as $group) {
+        $group_slug = trim((string) ($group['slug'] ?? ''));
+        $group_name = trim((string) ($group['name'] ?? $group_slug));
+        if ($group_slug === '') {
+            continue;
+        }
+        $ensure_term('affiliation', $group_slug, $group_name);
+        $affiliation_terms[] = $group_slug;
+    }
+
+    $rarity_terms = [];
+    if (!empty($spec['rarity'])) {
+        $rarity_terms[] = (string) $spec['rarity'];
+    }
+    if (!empty($spec['rarity_detail']) && $spec['rarity_detail'] !== 'none') {
+        $rarity_terms[] = (string) $spec['rarity_detail'];
+    }
+
+    $available_moji_terms = [];
+    foreach (($spec['chars'] ?? []) as $char) {
+        $char_slug = trim((string) ($char['slug'] ?? ''));
+        $char_val = trim((string) ($char['val'] ?? $char_slug));
+        if ($char_slug === '') {
+            continue;
+        }
+        $ensure_term('available_moji', $char_slug, $char_val);
+        $available_moji_terms[] = $char_slug;
+    }
+    $available_moji_terms = array_values(array_unique($available_moji_terms));
+
+    $gimmick_terms = [];
+    foreach (['trait1', 'trait2', 'blessing'] as $trait_key) {
+        foreach (($spec[$trait_key]['contents'] ?? []) as $trait) {
+            if (($trait['type'] ?? '') !== 'gimmick') {
+                continue;
+            }
+            $gimmick_slug = trim((string) ($trait['sub_type'] ?? ''));
+            if ($gimmick_slug === '') {
+                continue;
+            }
+            $ensure_term('gimmick', $gimmick_slug, $gimmick_label($gimmick_slug));
+            $gimmick_terms[] = $gimmick_slug;
+        }
+    }
+    $gimmick_terms = array_values(array_unique($gimmick_terms));
+
+    wp_set_object_terms($post_id, $attr_terms, 'attribute');
+    wp_set_object_terms($post_id, $species_terms, 'species');
+    wp_set_object_terms($post_id, $affiliation_terms, 'affiliation');
+    wp_set_object_terms($post_id, $rarity_terms, 'rarity');
+    wp_set_object_terms($post_id, $available_moji_terms, 'available_moji');
+    wp_set_object_terms($post_id, $gimmick_terms, 'gimmick');
+
+    $imported[] = [
+        'spec_id' => $spec_id,
+        'post_id' => (int) $post_id,
+        'title' => $post_title,
+    ];
+}
+
+wp_cache_flush();
+flush_rewrite_rules(false);
+
+echo wp_json_encode($imported, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT) . "\n";

--- a/single-character.php
+++ b/single-character.php
@@ -753,7 +753,11 @@ if ($ls_html): ?>
 // =================================================================
 ob_start();
 $waza_groups = $all_fields['waza_group_loop'] ?? null;
-$waza_name   = $all_fields['waza_name'] ?? null;
+$waza_name   = $all_fields['waza_name'] ?? ($spec_data['waza']['name'] ?? null);
+$waza_shift_type = $spec_data['waza']['shift_type'] ?? 'none';
+if (empty($waza_groups) && function_exists('kotodaman_local_build_skill_groups_from_spec')) {
+    $waza_groups = kotodaman_local_build_skill_groups_from_spec($spec_data['waza']['variations'] ?? [], 'waza', $waza_shift_type);
+}
 $calc_atk=$disp_atk_120 ?? ($disp_atk_99 ?? 0);
 
 if ($waza_groups):
@@ -771,7 +775,14 @@ $waza_html = ob_get_clean();
 ob_start();
 $sugo_condition = $all_fields['sugowaza_condition'] ?? null;
 $sugo_groups    = $all_fields['sugowaza_group_loop'] ?? null;
-$sugo_name      = $all_fields['sugowaza_name'] ?? null;
+$sugo_name      = $all_fields['sugowaza_name'] ?? ($spec_data['sugowaza']['name'] ?? null);
+$sugo_shift_type = $spec_data['sugowaza']['shift_type'] ?? 'none';
+if (empty($sugo_condition) && function_exists('kotodaman_local_build_sugowaza_conditions_from_spec')) {
+    $sugo_condition = kotodaman_local_build_sugowaza_conditions_from_spec($spec_data['sugowaza']['condition'] ?? []);
+}
+if (empty($sugo_groups) && function_exists('kotodaman_local_build_skill_groups_from_spec')) {
+    $sugo_groups = kotodaman_local_build_skill_groups_from_spec($spec_data['sugowaza']['variations'] ?? [], 'sugo', $sugo_shift_type);
+}
 
 if ($sugo_condition || $sugo_groups):
     echo '<div class="skill-card card-sugo">';


### PR DESCRIPTION
## 概要
09b7f48 で追加された詳細画面の「単純火力指数」で、多段攻撃の初段が二重集計される不具合を修正
- old: x.com/kotodamanDB/status/2046563365594816979
- new
  - <img width="640" height="336" alt="image" src="https://github.com/user-attachments/assets/cb4bbab1-a6d4-44eb-8111-7df8adff2f5e" />


ついでにローカル開発環境での火力指数確認周り (all_character_search.jsonだけじゃページ表示すらされないので)
- `testdata/spec-json` の5件だけから検索用 `all_characters_search.json` を生成しつつ、詳細ページでも確認できるhelperを local-dev に追加
- さらに火力指数表示にはACF の `waza_group_loop` / `sugowaza_group_loop` が必要なので、それをdevcontainer wp上で再現

## 詳細
原因は `lib/koto-display.php` の `get_koto_sugowaza_html()` にある多段攻撃の集計処理

`attack` / `converged_attack` で `hit_count > 1` の場合、すでに多段分の内訳を `$at_rate_array` に積んでいるにもかかわらず、単発用の `$raw_eff_val x 1` をさらに無条件追加していたため、初段相当の値が1回分余計

### Fix
- `hit_count <= 1` の場合のみ単発分を `$at_rate_array` に追加するよう修正
- `hit_count > 1` の場合は、すでに積まれている多段内訳のみを使用

## ローカル確認手順

### 1. 検索用JSONのローカル生成
`testdata/spec-json` の以下5件のみから `all_characters_search.json` を生成して配信確認

- `grand_hametsu.json`
- `grand_nheroop.json`
- `kyusei.json`
- `legend_ai.json`
- `yoyoyomi_iitaru.json`

確認結果:
- 配信件数: `5`
- 配信ID: `2015, 3554, 1564, 1800, 1709`

### 2. 実画面確認
`_spec_json` からローカル詳細画面を再現できるよう local-dev 補助を追加し、devcontainerのWP上で確認

対象: `依依たる想い・イィタル&ヨヨヨミ`

- before: `6314x2 + 6314 + 6765 + 4735x3 = 39912`
- after: `6314x2 + 6765 + 4735x3 = 33598`


### 3. JSONベース確認
- `yoyoyomi_iitaru.json`
  - `6314x2 + 6765 + 4735x3 = 33598`
- `kyusei.json` 多段ケース
  - before: `2563x4 + 2563 = 12815`
  - after: `2563x4 = 10252`
- `kyusei.json` 単発ケース
  - before: `6153 = 6153`
  - after: `6153 = 6153`
